### PR TITLE
Upgrade to Rebus 6 and Unity 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,8 @@
 
 * Update to Rebus 4
 * Port to new project structure
+
+## 6.0.0
+
+* Update to Rebus 6
+* Update to Unity 5

--- a/Rebus.Unity.Tests/Rebus.Unity.Tests.csproj
+++ b/Rebus.Unity.Tests/Rebus.Unity.Tests.csproj
@@ -34,8 +34,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.Unity\Rebus.Unity.csproj" />
-    <PackageReference Include="nunit" Version="3.7.1" />
-    <PackageReference Include="rebus" Version="4.0.0" />
-    <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="rebus" Version="6.6.0" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.4.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Unity.Tests/UnityContainerAdapterFactory.cs
+++ b/Rebus.Unity.Tests/UnityContainerAdapterFactory.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Practices.Unity;
 using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Handlers;
 using Rebus.Tests.Contracts.Activation;
+using Unity;
+using Unity.Injection;
 
 namespace Rebus.Unity.Tests
 {
@@ -49,7 +50,7 @@ namespace Rebus.Unity.Tests
                 {
                     var componentName = $"{typeof(THandler).FullName}:{handlerInterfaceType.FullName}";
 
-                    _unityContainer.RegisterType(handlerInterfaceType, typeof(THandler), componentName, new TransientLifetimeManager(), new InjectionMember[0]);
+                    _unityContainer.RegisterType(handlerInterfaceType, typeof(THandler), componentName, new InjectionMember[0]);
                 }
                 return this;
             }

--- a/Rebus.Unity/Rebus.Unity.csproj
+++ b/Rebus.Unity/Rebus.Unity.csproj
@@ -48,11 +48,11 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="rebus" Version="4.0.0" />
+    <PackageReference Include="rebus" Version="6.6.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="unity">
-      <Version>4.0.1</Version>
+      <Version>5.11.10</Version>
     </PackageReference>
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
Although there are no breaking changes, I suggest to release this as version 6.0.0 to keep the consistency going between the version of this package and the version of Rebus that it depends on.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
